### PR TITLE
fix: add upstream container for shim (v0.0.50)

### DIFF
--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -5,3 +5,23 @@ memory: 8192
 shim:
   upstream-port: 8080
   tls-mode: self-signed
+
+containers:
+  - name: "bridge-upstream"
+    image: "docker.io/library/nginx:alpine"
+    restart: always
+    read_only: false
+    cap_add: ["CHOWN", "SETUID", "SETGID", "DAC_OVERRIDE", "KILL"]
+    command:
+      - /bin/sh
+      - -c
+      - |
+        cat > /etc/nginx/conf.d/default.conf <<'EOF'
+        server {
+          listen 8080 default_server;
+          location /health { return 200 'ok\n'; }
+          location /tinfoil-marker { return 200 'bridge-mode-OK\n'; }
+          location /          { root /tinfoil; autoindex on; }
+        }
+        EOF
+        nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- Add a minimal `bridge-upstream` nginx container on port 8080 so the shim has a non-empty `UpstreamContainer` at boot.
- Fixes `v0.0.49`, which shipped a shim-only config and failed with: `resolving upstream container "": invalid container name or ID: value is empty`.

Reproduced on inf13: `rtmr049-prod` failed at the shim stage; a dev-launch with this container config reached `ready`.

## Test plan
- [ ] Merge PR
- [ ] Tag and push `v0.0.50` to trigger the release workflow:
  ```bash
  git checkout main && git pull
  git tag v0.0.50 && git push origin v0.0.50
  ```
- [ ] Confirm GitHub release publishes new `tinfoil-deployment.json` with updated `tinfoil-config-hash`
- [ ] Deploy on inf13:
  ```bash
  tinctl deploy tinfoilsh/confidential-debug --tag v0.0.50 --name rtmr049-prod2 --domain rtmr049.inf13.tinfoil.sh
  tinctl watch rtmr049-prod2
  ```
- [ ] Verify `https://rtmr049.inf13.tinfoil.sh/health` returns `ok`