### PR TITLE
Bump measure-image-action to v0.10.0 (vm_shape predicate)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-      - uses: tinfoilsh/measure-image-action@43349abfd0ec3c99c088b21db36ad0066f27f70a  # v0.8.1
+      - uses: tinfoilsh/measure-image-action@02f24fd03e2e79abc9a2044b1c8f380ae5bec9e3  # v0.10.0
         with:
           config-file: ${{ github.workspace }}/tinfoil-config.yml
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tinfoil-config.yml
+++ b/tinfoil-config.yml
@@ -1,5 +1,5 @@
 cvm-version: 0.10.4
-cpus: 2
+cpus: 4
 memory: 4096
 
 shim:


### PR DESCRIPTION
## Summary
- Pins `measure-image-action` to `v0.10.0`, whose deployment predicate declares the canonical VM shape (`vm_shape: {cpus, memory_mb, gpus, disks}`) alongside the measurements. The v3 verifier requires this member; v2 readers ignore it.
- Bumps the config to 4 CPUs so the declared shape (`{"cpus": 4, "memory_mb": 4096, "gpus": 0, "disks": 3}`) exactly matches the endorsed `mini_0d` platform shape — a TDX debug enclave then resolves an endorsed MRTD/RTMR0 with no platform-endorsements change (SEV launches don't consult the shape).

## Test plan
- [ ] Tag a release and confirm `tinfoil-deployment.json` carries `vm_shape: {"cpus": 4, "memory_mb": 4096, "gpus": 0, "disks": 3}`
- [ ] Launch on a TDX host with a `mini_0d`-endorsed policy and verify the v3 flow resolves the `mini_0d` platform measurement
